### PR TITLE
Fixes typo - zoom out on Sketch

### DIFF
--- a/Design/toolspage-sketch.html
+++ b/Design/toolspage-sketch.html
@@ -171,7 +171,7 @@
 <div class="toolspage-shortcuts-table">
     <table>
         <tr><td>Zoom in</td><td>⌘ +</td></tr>
-        <tr><td>Zoom out</td><td>⌘  </td></tr>
+        <tr><td>Zoom out</td><td>⌘ -</td></tr>
         <tr><td>Zoom to 100%</td><td>⌘ 0</td></tr>
         <tr><td>Zoom to all elements on Canvas</td><td>⌘ 1</td></tr>
         <tr><td>Zoom to selected layer(s)</td><td>⌘ 2</td></tr>


### PR DESCRIPTION
Addition of the "-" sign for Zoom Out shortcut on Sketch.