### PR TITLE
Add Prototyping shortcuts to Figma

### DIFF
--- a/data/Design/toolspage-figma-mac.html
+++ b/data/Design/toolspage-figma-mac.html
@@ -161,4 +161,11 @@
         <tr><td>Swap component instance</td><td>⌥</td></tr>
         <tr><td>Show components menu</td><td>⇧ I</td></tr>
     </tbody>
+    <tr><th colspan="2">Prototyping</th></tr>
+    <tbody>
+        <tr><td>Fullscreen</td><td>F</td></tr>
+        <tr><td>Scale view</td><td>Z</td></tr>
+        <tr><td>Restart prototype</td><td>R</td></tr>
+        <tr><td>Comment</td><td>C</td></tr>
+    </tbody>
 </table>


### PR DESCRIPTION
Was trying to look these up after a user of my extension ([KnowledgeOS](https://chrome.google.com/webstore/detail/knowledgeos%EF%B8%8F-by-comake/lckjfjnkngpmcommhajdilngdhdclica)) reported a bug when typing in an input in an overlay that can be opened over figma. Found out the bug was due to his typing triggering/conflicting with Figma hotkeys in prototyping mode. 

Love what you've created here! May be contributting more in the future!