### PR TITLE
Update Miro shortcuts to match latest state

### DIFF
--- a/data/Design/toolspage-miro-mac.html
+++ b/data/Design/toolspage-miro-mac.html
@@ -1,13 +1,14 @@
 <table id="myTable">
     <tr><th colspan="2">Tools</th></tr>
     <tbody>
-        <tr><td>Select tool / hand</td><td>V / H</td></tr>
+        <tr><td>Select tool/hand mode</td><td>V / H</td></tr>
         <tr><td>Text</td><td>T</td></tr>
         <tr><td>Sticky note</td><td>N</td></tr>
         <tr><td>Shapes</td><td>S</td></tr>
         <tr><td>Rectangle</td><td>R</td></tr>
         <tr><td>Oval</td><td>O</td></tr>
         <tr><td>Connection Line, arrow</td><td>L</td></tr>
+        <tr><td>Card</td><td>D</td></tr>
         <tr><td>Pen</td><td>P</td></tr>
         <tr><td>Eraser</td><td>E</td></tr>
         <tr><td>Comment</td><td>C</td></tr>
@@ -15,6 +16,9 @@
         <tr><td>Redo</td><td>⌘ ⇧ Z</td></tr>
         <tr><td>Frames</td><td>F</td></tr>
         <tr><td>Minimap</td><td>M</td></tr>
+        <tr><td>Link to</td><td>⌘ K</td></tr>
+        <tr><td>New sticky note in bulk mode</td><td>↩</td></tr>
+        <tr><td>Exit sticky note bulk mode</td><td>Esc</td></tr>
     </tbody>
     <tr><th colspan="2">General</th></tr>
     <tbody>
@@ -22,15 +26,17 @@
         <tr><td>Cut</td><td>⌘ X</td></tr>
         <tr><td>Duplicate</td><td>⌘ D</td></tr>
         <tr><td>Duplicate</td><td>⌥ Drag</td></tr>
+        <tr><td>Duplicate horizontally or vertically</td><td>⌥ ← → ↑ ↓</td></tr>
         <tr><td>Multi-select</td><td>⇧ Drag</td></tr>
         <tr><td>Select multiple items</td><td>⌘ Click</td></tr>
         <tr><td>Select all</td><td>⌘ A</td></tr>
         <tr><td>Edit selected item</td><td>↩ </td></tr>
         <tr><td>Deselect, quit edit, switch to cursor</td><td>Esc</td></tr>
-        <tr><td>Delete</td><td>Backspace</td></tr>
+        <tr><td>Delete</td><td>Delete</td></tr>
         <tr><td>Group</td><td>⌘ G</td></tr>
         <tr><td>Ungroup</td><td>⌘ ⇧ G</td></tr>
         <tr><td>Lock / Unlock</td><td>⌘ L</td></tr>
+        <tr><td>Protected lock/unprotected lock</td><td>⌘ ⇧ L</td></tr>
         <tr><td>Send to front</td><td>Fn ↑</td></tr>
         <tr><td>Send to back</td><td>Fn ↓ </td></tr>
     </tbody>
@@ -40,10 +46,16 @@
         <tr><td>Zoom in</td><td>⌘ +</td></tr>
         <tr><td>Zoom out</td><td>⌘ -</td></tr>
         <tr><td>Zoom to 100%</td><td>⌘ 0</td></tr>
-        <tr><td>Zoom to fit</td><td>⌘ 1</td></tr>
-        <tr><td>Zoom to selected item</td><td>⌘ 2</td></tr>
+        <tr><td>Zoom to fit</td><td>⌥ 1</td></tr>
+        <tr><td>Zoom to selected item</td><td>⌥ 2</td></tr>
         <tr><td>Move canvas</td><td>Space drag</td></tr>
         <tr><td>Toggle grid</td><td>G</td></tr>
         <tr><td>Search</td><td>⌘ F</td></tr>
+    </tbody>
+    <tr><th colspan="2">Text</th></tr>
+    <tbody>
+        <tr><td>Bold</td><td>⌘ B</td></tr>
+        <tr><td>Italic</td><td>⌘ I</td></tr>
+        <tr><td>Underline</td><td>⌘ U</td></tr>
     </tbody>
 </table>

--- a/data/Design/toolspage-miro-windows.html
+++ b/data/Design/toolspage-miro-windows.html
@@ -1,20 +1,24 @@
 <table id="myTable">
     <tr><th colspan="2">Tools</th></tr>
     <tbody>
-        <tr><td>Select tool / hand</td><td>V / H</td></tr>
+        <tr><td>Select tool/hand mode</td><td>V / H</td></tr>
         <tr><td>Text</td><td>T</td></tr>
         <tr><td>Sticky note</td><td>N</td></tr>
         <tr><td>Shapes</td><td>S</td></tr>
         <tr><td>Rectangle</td><td>R</td></tr>
         <tr><td>Oval</td><td>O</td></tr>
         <tr><td>Connection Line, arrow</td><td>L</td></tr>
+        <tr><td>Card</td><td>D</td></tr>
         <tr><td>Pen</td><td>P</td></tr>
         <tr><td>Eraser</td><td>E</td></tr>
         <tr><td>Comment</td><td>C</td></tr>
         <tr><td>Undo</td><td>CTRL Z</td></tr>
         <tr><td>Redo</td><td>CTRL ⇧ Z</td></tr>
-        <tr><td>Frames</td><td>F</td></tr>
+        <tr><td>Frame</td><td>F</td></tr>
         <tr><td>Minimap</td><td>M</td></tr>
+        <tr><td>Link to</td><td>CTRL K</td></tr>
+        <tr><td>New sticky note in bulk mode</td><td>Enter</td></tr>
+        <tr><td>Exit sticky note bulk mode</td><td>Esc</td></tr>
     </tbody>
     <tr><th colspan="2">General</th></tr>
     <tbody>
@@ -22,6 +26,7 @@
         <tr><td>Cut</td><td>CTRL X</td></tr>
         <tr><td>Duplicate</td><td>CTRL D</td></tr>
         <tr><td>Duplicate</td><td>ALT Drag</td></tr>
+        <tr><td>Duplicate horizontally or vertically</td><td>Alt ← → ↑ ↓</td></tr>
         <tr><td>Multi-select</td><td>⇧ Drag</td></tr>
         <tr><td>Select multiple items</td><td>CTRL Click</td></tr>
         <tr><td>Select all</td><td>CTRL A</td></tr>
@@ -31,6 +36,7 @@
         <tr><td>Group</td><td>CTRL G</td></tr>
         <tr><td>Ungroup</td><td>CTRL ⇧ G</td></tr>
         <tr><td>Lock / Unlock</td><td>CTRL L</td></tr>
+        <tr><td>Protected lock/unprotected lock</td><td>CTRL ⇧ L</td></tr>
         <tr><td>Send to front</td><td>PgUp</td></tr>
         <tr><td>Send to back</td><td>PgDn</td></tr>
     </tbody>
@@ -45,5 +51,11 @@
         <tr><td>Move canvas</td><td>Space drag</td></tr>
         <tr><td>Toggle grid</td><td>G</td></tr>
         <tr><td>Search</td><td>CTRL F</td></tr>
+    </tbody>
+    <tr><th colspan="2">Text</th></tr>
+    <tbody>
+        <tr><td>Bold</td><td>CTRL B</td></tr>
+        <tr><td>Italic</td><td>CTRL I</td></tr>
+        <tr><td>Underline</td><td>CTRL U</td></tr>
     </tbody>
 </table>


### PR DESCRIPTION
The list of shortcuts for Miro were not complete and up to date.

For Chrome on MacOS, at least, the zooming shortcuts switched:
 - Zoom to fit: `⌘ + 1` -> `⌥ + 1`
 - Zoom to selected: `⌘ + 2` -> `⌥ + 2`