### PR TITLE
New shortcut added in figma 'set opacity to 0 -> 00'

### DIFF
--- a/data/Design/toolspage-figma-mac.html
+++ b/data/Design/toolspage-figma-mac.html
@@ -133,6 +133,7 @@
         <tr><td>Edit shape or image</td><td>↩ </td></tr>
         <tr><td>Place image</td><td>⇧ ⌘ K</td></tr>
         <tr><td>Crop image</td><td>⌥ Double-click</td></tr>
+        <tr><td>Set opacity to 0</td><td>00</td></tr>
         <tr><td>Set opacity to 10</td><td>1</td></tr>
         <tr><td>Set opacity to 50</td><td>5</td></tr>
         <tr><td>Set opacity to 100</td><td>0</td></tr>

--- a/data/Design/toolspage-figma-windows.html
+++ b/data/Design/toolspage-figma-windows.html
@@ -133,6 +133,7 @@
         <tr><td>Edit shape or image</td><td>↩ </td></tr>
         <tr><td>Place image</td><td>⇧ CTRL K</td></tr>
         <tr><td>Crop image</td><td>Alt Double-click</td></tr>
+        <tr><td>Set opacity to 0</td><td>00</td></tr>
         <tr><td>Set opacity to 10</td><td>1</td></tr>
         <tr><td>Set opacity to 50</td><td>5</td></tr>
         <tr><td>Set opacity to 100</td><td>0</td></tr>


### PR DESCRIPTION
<img width="1126" alt="Screenshot 2025-06-13 at 7 33 30 PM" src="https://github.com/user-attachments/assets/d4586434-b357-40bd-befc-b41099111101" />


Added new Shortcut for setting opacity to zero which is double click "0"